### PR TITLE
fixed example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ match rexif::parse_file(&file_name) {
 
         for entry in &exif.entries {
             println!("    {}: {}",
-                    entry.tag_readable,
+                    entry.tag,
                     entry.value_more_readable);
         }
     },
@@ -39,4 +39,3 @@ The included tool `refixtool` accepts image file names as command-line
 parameters and prints EXIF data for them. The `src/main.rs` file is a
 good starting point to learn how to use the crate, then take a look into
 the `ExifEntry` struct.
-


### PR DESCRIPTION
The code in the README.md (https://crates.io/crates/rexif) doesn't compile.

I would have just opened an issue, but the repo is not allowing other parties to create issues. As a feature, it would be great if the Unkown tag ID values were printed. Then users could look up the tag ID on a page like [this one](https://exiv2.org/tags.html) until most of the common tags are implemented. It would be very helpful, as I haven't even been able to find a JPEG yet that doesn't have unknown tags when processed by `rexif`.

Thanks!